### PR TITLE
Rewrite client to be implemented with React.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: scala
 jdk: oraclejdk8
+before_script:
+  - cd ..
+  - git clone https://github.com/payalabs/scalajs-react-mdl.git
+  - cd scalajs-react-mdl
+  - sbt publishLocal
+  - cd ../funky-dashboard
 script:
   - sbt compile
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ notifications:
       - team846:C7msa8tAKGdHScWVPPVL3DnB
     on_success: change
     on_failure: always
+branches:
+  only:
+    - master

--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,14 @@ publish := {}
 publishLocal := {}
 
 val sjsFiles = Def.taskDyn {
-  (fullOptJS in (client, Compile)).map { _ =>
+  (fastOptJS in (client, Compile)).map { _ =>
     val root = (crossTarget in client).value / "server-resources" / "META-INF" / "resources"
     Seq(
       root,
       root / "sjs",
+      root / "sjs" / "client-fastopt.js",
       root / "sjs" / "client-opt.js",
+      root / "sjs" / "client-jsdeps.js",
       root / "sjs" / "client-jsdeps.min.js",
       root / "sjs" / "client-launcher.js"
     )
@@ -27,7 +29,7 @@ lazy val server = project.settings(
 )
 
 lazy val client = project.settings(
-  Seq(packageScalaJSLauncher, fullOptJS, packageJSDependencies) map { packageJSKey =>
+  Seq(packageScalaJSLauncher, fastOptJS, fullOptJS, packageJSDependencies, packageMinifiedJSDependencies) map { packageJSKey =>
     crossTarget in (Compile, packageJSKey) := crossTarget.value / "server-resources" / "META-INF" / "resources"/ "sjs"
   },
   publish := {},

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -5,3 +5,15 @@ scalaVersion := "2.11.7"
 persistLauncher := true
 
 libraryDependencies += "be.doeraene" %%% "scalajs-jquery" % "0.8.1"
+
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.0"
+
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.11.0"
+
+libraryDependencies += "com.payalabs" %%% "scalajs-react-mdl" % "0.2.0-SNAPSHOT"
+
+jsDependencies ++= Seq(
+  "org.webjars.bower" % "react" % "15.0.1" / "react-with-addons.js" minified "react-with-addons.min.js" commonJSName "React",
+  "org.webjars.bower" % "react" % "15.0.1" / "react-dom.js" minified "react-dom.min.js" dependsOn "react-with-addons.js" commonJSName "ReactDOM",
+  "org.webjars" % "flot" % "0.8.3-1" / "jquery.flot.min.js"
+)

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/Dashboard.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/Dashboard.scala
@@ -1,0 +1,118 @@
+package com.lynbrookrobotics.funkydashboard
+
+import japgolly.scalajs.react.vdom.all._
+import japgolly.scalajs.react.{BackendScope, Callback, ReactComponentB}
+import org.scalajs.dom.ext.Ajax
+
+import scala.scalajs.js
+import scala.scalajs.js.JSON
+import com.payalabs.scalajs.react.mdl._
+import org.scalajs.dom._
+
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+object DashboardContainer {
+  class Backend($: BackendScope[Unit, List[DatasetGroup]]) {
+    def componentDidMount: Callback = Callback {
+      Ajax.get("/datasets.json").foreach { result =>
+        $.setState(JSON.parse(result.responseText).asInstanceOf[js.Array[DatasetGroup]].toList).runNow()
+      }
+    }
+
+    def render(state: List[DatasetGroup]) = {
+      div(
+        Dashboard(state)
+      )
+    }
+  }
+
+  val component = ReactComponentB[Unit](getClass.getSimpleName)
+    .initialState(List.empty[DatasetGroup])
+    .renderBackend[Backend]
+    .componentDidMount(_.backend.componentDidMount)
+    .build
+
+  def apply() = component()
+}
+
+object Dashboard {
+  case class Props(groups: List[DatasetGroup])
+
+  class Backend($: BackendScope[Props, (Boolean, Int, List[Map[String, Map[String, js.Any]]])]) {
+    val websocketProtocol = if (window.location.protocol == "https") {
+      "wss"
+    } else {
+      "ws"
+    }
+
+    def componentDidMount: Callback = Callback {
+      val datastream = new WebSocket(s"$websocketProtocol://${window.location.host}/datastream")
+      datastream.onmessage = (e: MessageEvent) => {
+        val newValues = List(JSON.parse(e.data.toString).asInstanceOf[js.Dictionary[js.Any]].
+          toMap.mapValues(_.asInstanceOf[js.Dictionary[js.Any]].toMap))
+        $.modState { state =>
+          state.copy(
+            _3 = (state._3 ++ newValues).takeRight(50)
+          )
+        }.runNow()
+      }
+    }
+
+    def render(props: Props, state: (Boolean, Int, List[Map[String, Map[String, js.Any]]])) = {
+      import props._
+      val (paused, activeGroupIndex, pointsWindow) = state
+
+      div(className := "mdl-layout mdl-js-layout mdl-layout--fixed-drawer mdl-layout--fixed-header")(
+        header(className := "mdl-layout__header")(
+          div(className := "mdl-layout__header-row")(
+            span(className := "mdl-layout-title")("Funky Dashboard"),
+            div(className := "mdl-layout-spacer"),
+            button(
+              id := "pause-button",
+              className := "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
+            )("Toggle Pause").material
+          )
+        ),
+        div(className := "mdl-layout__drawer mdl-color--blue-grey-900 mdl-color-text--blue-grey-50")(
+          header(
+            img(src := "/images/Team_846_Logo.png", className := "team-logo")
+          ),
+          nav(id := "group-chooser", className := "group-chooser mdl-navigation mdl-color--blue-grey-800")(
+            groups.zipWithIndex.map { case (group, index) =>
+              a(
+                className := "mdl-navigation__link",
+                backgroundColor := (if (index == activeGroupIndex) "#00ACC1" else "transparent"),
+                cursor := "pointer",
+                onClick --> $.modState(_.copy(_2 = index))
+              )(group.name)
+            }
+          )
+        ),
+        main(className := "mdl-layout__content mdl-color--grey-100", id := "groups-container")(
+          div(className := "mdl-grid")(
+            if (activeGroupIndex < groups.size) {
+              val group = groups(activeGroupIndex)
+              group.datasets.map { d =>
+                DatasetCard(
+                  d.name,
+                  Dataset.extract(d)(pointsWindow.flatMap(_.get(group.name).flatMap(_.get(d.name))))
+                )
+              }
+            } else {
+              h1("Loading")
+            }
+          )
+        )
+      ).material
+    }
+  }
+
+  val component = ReactComponentB[Props](getClass.getSimpleName)
+    .initialState((false, 0, List.empty[Map[String, Map[String, js.Any]]]))
+    .renderBackend[Backend]
+    .componentDidMount(_.backend.componentDidMount)
+    .build
+
+  def apply(groups: List[DatasetGroup]) =
+    component(Props(groups))
+}

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/DashboardClient.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/DashboardClient.scala
@@ -1,92 +1,17 @@
 package com.lynbrookrobotics.funkydashboard
 
+import japgolly.scalajs.react.ReactDOM
+import org.scalajs.dom
 import org.scalajs.dom.ext.Ajax
+
 import scala.scalajs.js
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
-
-import scala.scalajs.js.{JSON, JSApp}
+import scala.scalajs.js.{JSApp, JSON}
 import org.scalajs.dom._
 import org.scalajs.jquery._
 
 object DashboardClient extends JSApp {
-  val groupChooser = jQuery("#group-chooser")
-  val sideDrawer = jQuery(".mdl-layout__drawer")
-  lazy val pauseButton = document.getElementById("pause-button").asInstanceOf[html.Button]
-
-  val websocketProtocol = if (window.location.protocol == "https") {
-    "wss"
-  } else {
-    "ws"
-  }
-
-  var pause = false
-  def initWebsocket(datasetsTree: Map[String, (Map[String, Dataset[Nothing]], () => Boolean)]): Unit = {
-    val datastream = new WebSocket(s"$websocketProtocol://${window.location.host}/datastream")
-    datastream.onmessage = (e: MessageEvent) => {
-      if (!pause) {
-        val currentDataDictionary = JSON.parse(e.data.toString).asInstanceOf[js.Dictionary[js.Any]]
-        currentDataDictionary.foreach { case (groupName, datasetsObject) =>
-          val datasets = datasetsObject.asInstanceOf[js.Dictionary[js.Any]]
-          val group = datasetsTree(groupName)
-
-          if (group._2()) {
-            datasets.foreach { case (datasetName, currentValueObject) =>
-              group._1(datasetName).update(currentValueObject)
-            }
-          }
-        }
-      }
-    }
-  }
-
   def main(): Unit = {
-    pauseButton.onclick = (e: MouseEvent) => {
-      pause = !pause
-    }
-
-    Ajax.get("/datasets.json").foreach { result =>
-      val datasetGroups = JSON.parse(result.responseText).asInstanceOf[js.Array[DatasetGroup]]
-      val tree = datasetGroups.toList.zipWithIndex.map { case (datasetGroup, index) =>
-        val groupView = document.createElement("div").asInstanceOf[html.Div]
-        groupView.className = "mdl-grid group-view"
-        val datasets = datasetGroup.datasets.map { datasetDefinition =>
-          val dataset = Dataset.extract(datasetDefinition)
-          groupView.appendChild(dataset.card)
-          datasetDefinition.name -> dataset
-        }.toMap
-
-        var isVisible = index == 0
-        groupView.style.display = if (index == 0) "flex" else "none"
-        document.getElementById("groups-container").appendChild(groupView)
-
-        val sidebarLink = document.createElement("a").asInstanceOf[html.Anchor]
-        sidebarLink.className = "mdl-navigation__link"
-        sidebarLink.innerHTML = datasetGroup.name
-        sidebarLink.href = ""
-        sidebarLink.style.backgroundColor = if (index == 0) "#00ACC1" else "transparent"
-        sidebarLink.onclick = (e: MouseEvent) => {
-          jQuery(".group-view").get().foreach { elem =>
-            elem.asInstanceOf[html.Div].style.display =
-              if (groupView == elem) "flex" else "none"
-          }
-
-          jQuery(".mdl-navigation__link").get().foreach { elem =>
-            elem.asInstanceOf[html.Anchor].style.backgroundColor =
-              if (sidebarLink == elem) "#00ACC1" else "transparent"
-          }
-
-          sideDrawer.removeClass("is-visible")
-
-          isVisible = true
-          e.preventDefault()
-        }
-
-        groupChooser.append(sidebarLink)
-
-        datasetGroup.name -> (datasets, () => isVisible)
-      }.toMap
-
-      initWebsocket(tree)
-    }
+    ReactDOM.render(DashboardContainer(), dom.document.getElementById("main-container"))
   }
 }

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/Dataset.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/Dataset.scala
@@ -1,39 +1,19 @@
 package com.lynbrookrobotics.funkydashboard
 
-import org.scalajs.dom._
-
-import scala.scalajs.js
-
-abstract class Dataset[-U](name: String) {
-  val dataDisplay: html.Element
-  lazy val card: html.Element = {
-    val baseElement = document.createElement("div").asInstanceOf[html.Div]
-    baseElement.className = "mdl-card mdl-shadow--16dp mdl-cell mdl-cell--6-col"
-    baseElement.style.minHeight = "0px"
-    baseElement.appendChild(dataDisplay)
-
-    val cardTitle = document.createElement("div").asInstanceOf[html.Div]
-    cardTitle.className = "mdl-card__title"
-    cardTitle.innerHTML = name
-    baseElement.appendChild(cardTitle)
-
-    baseElement
-  }
-
-  def update(newData: js.Any): Unit = {
-    updateDisplay(newData.asInstanceOf[U])
-  }
-
-  def updateDisplay(newData: U)
-}
+import japgolly.scalajs.react.{ReactComponentU, TopNode}
 
 object Dataset {
-  def extract(definition: DatasetDefinition): Dataset[Nothing] = {
+  def extract(definition: DatasetDefinition): List[Any] => ReactComponentU[_, _, _, TopNode] = {
     definition.`type` match {
       case "time-series-numeric" =>
-        new TimeSeriesNumeric(definition.name, definition.properties.asInstanceOf)
+        values => TimeSeriesNumeric(
+          definition.properties.asInstanceOf[TimeSeriesNumericProperties],
+          values.map(_.asInstanceOf[String])
+        )
       case "image-stream" =>
-        new ImageStream(definition.name)
+        values => ImageStream(
+          values.map(_.asInstanceOf[String])
+        )
     }
   }
 }

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/DatasetCard.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/DatasetCard.scala
@@ -1,0 +1,30 @@
+package com.lynbrookrobotics.funkydashboard
+
+import japgolly.scalajs.react.vdom.all._
+import japgolly.scalajs.react.{BackendScope, ReactComponentB, ReactElement}
+
+object DatasetCard {
+  case class Props(name: String, child: ReactElement)
+
+  class Backend($: BackendScope[Props, Unit]) {
+    def render(props: Props) = {
+      div(
+        key := props.name,
+        className := "mdl-card mdl-shadow--16dp mdl-cell mdl-cell--6-col",
+        minHeight := "0px"
+      )(
+        props.child,
+        div(className := "mdl-card__title")(props.name)
+      )
+    }
+  }
+
+  val component = ReactComponentB[Props](getClass.getSimpleName)
+    .stateless
+    .renderBackend[Backend]
+    .build
+
+  def apply(name: String, child: ReactElement) = {
+    component(Props(name, child))
+  }
+}

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/FlotLineChart.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/FlotLineChart.scala
@@ -1,0 +1,48 @@
+package com.lynbrookrobotics.funkydashboard
+
+import com.lynbrookrobotics.flot.Flot._
+import japgolly.scalajs.react.{BackendScope, Callback, ReactComponentB}
+import japgolly.scalajs.react.vdom.all._
+import org.scalajs.dom.html
+import org.scalajs.jquery.jQuery
+
+import scala.scalajs.js
+import js.JSConverters._
+
+object FlotLineChart {
+  case class Props(newPoints: List[Double])
+
+  class Backend($: BackendScope[Props, Unit]) {
+    def displayPlot = Callback {
+      jQuery.plot(
+        $.refs("chart-container").asInstanceOf[html.Div],
+        js.Array(
+          js.Dynamic.literal(
+            data = $.props.runNow().newPoints.zipWithIndex.map(t => js.Array(t._2, t._1)).toJSArray,
+            lines = js.Dynamic.literal(
+              show = true,
+              fill = true
+            )
+          )
+        )
+      )
+    }
+
+    def render(props: Props) = {
+      // 16:9 aspect ratio assuming width of 576px (on full-screen Retina MBP)
+      div(ref := "chart-container", height := "324px", width := "100%")
+    }
+  }
+
+  val component = ReactComponentB[Props](getClass.getSimpleName)
+    .stateless
+    .renderBackend[Backend]
+    .shouldComponentUpdate(_ => false)
+    .componentDidMount(_.backend.displayPlot)
+    .componentWillReceiveProps(_.component.backend.displayPlot)
+    .build
+
+  def apply(newPoints: List[Double]) = {
+    component(Props(newPoints))
+  }
+}

--- a/client/src/main/scala/com/lynbrookrobotics/funkydashboard/ImageStream.scala
+++ b/client/src/main/scala/com/lynbrookrobotics/funkydashboard/ImageStream.scala
@@ -1,20 +1,29 @@
 package com.lynbrookrobotics.funkydashboard
 
-import org.scalajs.dom._
+import japgolly.scalajs.react.{BackendScope, Callback, ReactComponentB, ReactComponentU, TopNode}
+import japgolly.scalajs.react.vdom.all._
 
-import scala.scalajs.js
-import org.scalajs.jquery._
+object ImageStream {
+  case class Props(newPoints: List[String])
 
-import com.lynbrookrobotics.flot.Flot._
+  class Backend($: BackendScope[Props, Unit]) {
+    def render(props: Props) = {
+      val images = $.props.runNow().newPoints
+      val last = if (images.nonEmpty) images.last else ""
 
-class ImageStream(name: String) extends Dataset[String](name) {
-  val image = document.createElement("img").asInstanceOf[html.Image]
-  image.style.width = "100%"
+      div(
+        img(src := s"data:image/png;base64,$last")
+      )
+    }
+  }
 
-  override val dataDisplay: html.Element = document.createElement("div").asInstanceOf[html.Div]
-  dataDisplay.appendChild(image)
+  val component = ReactComponentB[Props](getClass.getSimpleName)
+    .stateless
+    .renderBackend[Backend]
+    .shouldComponentUpdate(_.nextProps.newPoints.nonEmpty)
+    .build
 
-  override def updateDisplay(newData: String): Unit = {
-    image.src = s"data:image/png;base64,$newData"
+  def apply(newPoints: List[String]) = {
+    component(Props(newPoints))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")

--- a/server/src/main/resources/META-INF/resources/index.html
+++ b/server/src/main/resources/META-INF/resources/index.html
@@ -5,29 +5,13 @@
         <link rel="stylesheet" href="/main.css">
     </head>
     <body>
-    <div class="demo-layout mdl-layout mdl-js-layout mdl-layout--fixed-drawer mdl-layout--fixed-header">
-        <header class="mdl-layout__header">
-            <div class="mdl-layout__header-row">
-                <span class="mdl-layout-title">Funky Dashboard</span>
-                <div class="mdl-layout-spacer"></div>
-                <!-- Accent-colored raised button with ripple -->
-                <button id="pause-button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
-                    Toggle Pause
-                </button>
-            </div>
-        </header>
-        <div class="mdl-layout__drawer mdl-color--blue-grey-900 mdl-color-text--blue-grey-50">
-            <header>
-                <img src="/images/Team_846_Logo.png" class="team-logo">
-            </header>
-            <nav id="group-chooser" class="group-chooser mdl-navigation mdl-color--blue-grey-800"></nav>
-        </div>
-        <main class="mdl-layout__content mdl-color--grey-100" id="groups-container"></main>
+        <div id="main-container"></div>
 
         <script src="/webjars/material-design-lite/1.0.5/material.min.js"></script>
         <script src="/webjars/jquery/2.1.3/jquery.min.js"></script>
         <script src="/webjars/flot/0.8.3/jquery.flot.min.js"></script>
-        <script src="/sjs/client-opt.js"></script>
+        <script src="/sjs/client-jsdeps.js"></script>
+        <script src="/sjs/client-fastopt.js"></script>
         <script src="/sjs/client-launcher.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Summary:
+ Changes all dataset rendering implementations to be their own components
+ Uses scalajs-react-mdl for rendering Material Design Lite components

Test Plan:
+ Verified that the Funky Dashboard demo renders charts properly
+ Verified that switching groups works properly and updates graphs to the correct windows

Asana: https://app.asana.com/0/141927956784787/147317646965760

Reviewers: @sanghakchun